### PR TITLE
More Fixes

### DIFF
--- a/Carsa's Commands.lua
+++ b/Carsa's Commands.lua
@@ -2059,7 +2059,7 @@ COMMANDS = {
 	},
 	revokeRole = {
 		func = function(caller_id, target_id, role)
-			if Role.exists(target_id,role) then
+			if Role.exists(caller_id,role) then
 				Player.removeRole(caller_id, target_id, role)
 			end
 		end,


### PR DESCRIPTION
Added ammo definitions for diving and scuba gear
Did stuff to Player.removeRole function to use a table instead of nil
Did stuff to the command definitions of giveRole and revokeRole to use a table instead of nil
Did stuff to the playerRoles command to use a table instead of nil
Accidentally left in a test announce on line 2229
Added if statement for fuzzyStringInTable function inside of equipmentIDs command to prevent nil error when providing no argument
Added if statement for equipmentIDs subtitle announce to only post titles for equipment sizes that met argument criteria