### PR TITLE
Issue 76

### DIFF
--- a/src/script.lua
+++ b/src/script.lua
@@ -1,5 +1,5 @@
 -- CARSA'S COMMANDS
----@version 2.0.0
+---@version 2.0.1
 
 ---@alias peerID number
 ---@alias steamID string
@@ -15,8 +15,8 @@ local OWNER_STEAM_ID = "0"
 
 local DEBUG = false
 
-local ScriptVersion = "2.0.0"
-local SaveDataVersion = "2.0.0"
+local ScriptVersion = "2.0.1"
+local SaveDataVersion = "2.0.1"
 
 --[ LIBRARIES ]--
 --#region

--- a/src/script.lua
+++ b/src/script.lua
@@ -2936,6 +2936,30 @@ end
 --[ CALLBACK FUNCTIONS ]--
 --#region
 
+g_savedata.version = SaveDataVersion
+g_savedata.autosave = g_savedata.autosave or 1
+g_savedata.is_dedicated_server = g_savedata.is_dedicated_server or false
+-- define if undefined
+g_savedata.vehicles = g_savedata.vehicles or {}
+g_savedata.objects = g_savedata.objects or {}
+g_savedata.players = g_savedata.players or {}
+g_savedata.roles = g_savedata.roles or deepCopyTable(DEFAULT_ROLES)
+g_savedata.unique_players = g_savedata.unique_players or 0
+g_savedata.preferences = g_savedata.preferences or deepCopyTable(PREFERENCE_DEFAULTS)
+g_savedata.rules = g_savedata.rules or {}
+g_savedata.aliases = g_savedata.aliases or deepCopyTable(DEFAULT_ALIASES)
+g_savedata.companionTokens = g_savedata.companionTokens or {}
+
+-- create references to shorten code
+G_vehicles = G_vehicles or new(VehicleContainer) ---@type VehicleContainer
+G_objects = g_savedata.objects -- Not in use yet
+G_players = new(PlayerContainer) ---@type PlayerContainer
+G_roles = new(RoleContainer) ---@type RoleContainer
+G_rules = new(Rules) ---@type Rules
+G_preferences = g_savedata.preferences
+G_aliases = g_savedata.aliases
+G_companionTokens = g_savedata.companionTokens
+
 function onCreate(is_new)
 	deny_tp_ui_id = server.getMapID()
 
@@ -2954,31 +2978,6 @@ function onCreate(is_new)
 	end
 
 	if invalid_version then return end
-
-
-	g_savedata.version = SaveDataVersion
-	g_savedata.autosave = g_savedata.autosave or 1
-	g_savedata.is_dedicated_server = g_savedata.is_dedicated_server or false
-	-- define if undefined
-	g_savedata.vehicles = g_savedata.vehicles or {}
-	g_savedata.objects = g_savedata.objects or {}
-	g_savedata.players = g_savedata.players or {}
-	g_savedata.roles = g_savedata.roles or deepCopyTable(DEFAULT_ROLES)
-	g_savedata.unique_players = g_savedata.unique_players or 0
-	g_savedata.preferences = g_savedata.preferences or deepCopyTable(PREFERENCE_DEFAULTS)
-	g_savedata.rules = g_savedata.rules or {}
-	g_savedata.aliases = g_savedata.aliases or deepCopyTable(DEFAULT_ALIASES)
-	g_savedata.companionTokens = g_savedata.companionTokens or {}
-
-	-- create references to shorten code
-	G_vehicles = G_vehicles or new(VehicleContainer) ---@type VehicleContainer
-	G_objects = g_savedata.objects -- Not in use yet
-	G_players = new(PlayerContainer) ---@type PlayerContainer
-	G_roles = new(RoleContainer) ---@type RoleContainer
-	G_rules = new(Rules) ---@type Rules
-	G_preferences = g_savedata.preferences
-	G_aliases = g_savedata.aliases
-	G_companionTokens = g_savedata.companionTokens
 
 	is_dedicated_server = g_savedata.is_dedicated_server
 


### PR DESCRIPTION
It looks like `onVehicleSpawn()` is getting called before `onCreate()` so we cannot guarantee that `g_savedata` is initialized before being needed.

![image](https://user-images.githubusercontent.com/61925890/186313926-0fbd69a6-f76c-4e5b-ba6c-ef4bed692cd1.png)

This leads to `nil` exceptions, especially when syncing with the companion web app.

This PR moves the initializing of `g_savedata` variables to be executed immediately and not in `onCreate()` to hopefully fix this issue. 

Fixes #76, #75

Also seems to fix #77, I assume it was linked as `onVehicleSpawn()` was getting called before `onCreate()` and it was corrupting `G_vehicles` somehow.