### PR TITLE
Add `editableVehicles` preference

### DIFF
--- a/src/script.lua
+++ b/src/script.lua
@@ -1505,6 +1505,10 @@ local PREFERENCE_DEFAULTS = {
 	adminAll = {
 		value = false,
 		type = "boolean"
+	},
+	editableVehicles = {
+		value = true,
+		type = "boolean"
 	}
 }
 
@@ -3493,6 +3497,11 @@ function onVehicleSpawn(vehicleID, peerID, x, y, z, cost)
 				}
 			)
 		end
+
+		if not G_preferences.editableVehicles.value then
+			server.setVehicleEditable(vehicleID, false)
+		end
+
 		owner.latest_spawn = vehicleID
 		owner.save()
 	else

--- a/src/script.lua
+++ b/src/script.lua
@@ -3216,6 +3216,7 @@ function onCreate(is_new)
 		G_preferences.keepInventory.value = property.checkbox("Keep inventory on death", "true")
 		G_preferences.removeVehicleOnLeave.value = property.checkbox("Remove player's vehicle on leave", "true")
 		G_preferences.maxVoxels.value = property.slider("Max vehicle voxel size", 0, 10000, 10, 0)
+		G_preferences.editableVehicles.value = property.checkbox("Vehicles are editable by default", "true")
 
 		local adminAll = property.checkbox("Admin all players", "false")
 		local everyoneRole = G_roles.get("Everyone")


### PR DESCRIPTION
Adds a new preference `editableVehicles` that defaults to true, meaning player vehicles are, by default, true. If toggled off in the addon config menu or using `?setPref`, any newly spawned player vehicles should be uneditable.

So far, this is completely untested, just opening to show some life. Will need to make sure that when the world is reloaded, previously uneditable vehicles are still uneditable. If they *somehow* are not, we will need to save a `editable` state to `G_Vehicles` for each vehicle so that `onCreate` we can set the edit states of all the vehicles.

Things to test:
- [x] Vehicles are editable by default
- [x] Server vehicles are unaffected
- [x] When `editableVehicles` is set to false, new vehicles cannot be edited
- [x] When `editableVehicles` is set to false, server vehicles are still unaffected
- [x] When `editableVehicles` is set *back* to true, new vehicles can be edited
- [x] When `editableVehicles` is set *back* to true, old vehicles cannot be edited
- [x] On reload, vehicles that were spawned as uneditable are still unable to be edited

Closes #95 