### PR TITLE
fix #98 bump SaveDataVersion to 2.1.3

### DIFF
--- a/src/script.lua
+++ b/src/script.lua
@@ -18,7 +18,7 @@ local OWNER_STEAM_ID = "0"
 local DEBUG = false
 
 local ScriptVersion = "2.1.3"
-local SaveDataVersion = "2.1.1"
+local SaveDataVersion = "2.1.3"
 
 --[ LIBRARIES ]--
 --#region


### PR DESCRIPTION
While 3b974ed adds a safety check to avoid throwing an error, it does not fix the underlying issue of the `compareVersions()` function returning false and the new preference not being added.